### PR TITLE
🔒 fix(security): restrict CORS allowed origins

### DIFF
--- a/packages/deepfix-portal/.env.example
+++ b/packages/deepfix-portal/.env.example
@@ -30,5 +30,8 @@ SMTP_HOST=smtp.gmail.com
 SMTP_PORT=465
 SMTP_USE_TLS=true
 
-# Frontend URL for verification links
+# Frontend URL for verification links and CORS
 FRONTEND_URL=http://localhost:5173
+
+# Comma-separated list of additional allowed CORS origins
+# CORS_ALLOWED_ORIGINS=https://portal.example.com,https://app.example.com

--- a/packages/deepfix-portal/src/deepfix_portal/api/main.py
+++ b/packages/deepfix-portal/src/deepfix_portal/api/main.py
@@ -23,12 +23,30 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# CORS middleware - configure for your frontend
+# CORS configuration
+# Defaults for local development
+default_origins = ["http://localhost:5173", "http://localhost:8844"]
+
+# Allowed origins from environment variable (comma-separated list)
+cors_origins_env = os.getenv("CORS_ALLOWED_ORIGINS", "")
+allowed_origins = (
+    [origin.strip() for origin in cors_origins_env.split(",") if origin.strip()]
+    if cors_origins_env
+    else []
+)
+
+# Add FRONTEND_URL if present
+frontend_url = os.getenv("FRONTEND_URL")
+if frontend_url and frontend_url not in allowed_origins:
+    allowed_origins.append(frontend_url)
+
+# Use defaults if no origins specified via environment
+if not allowed_origins:
+    allowed_origins = default_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "*",
-    ],  # Add your frontend URLs
+    allow_origins=allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/packages/deepfix-portal/tests/api/test_cors.py
+++ b/packages/deepfix-portal/tests/api/test_cors.py
@@ -1,0 +1,66 @@
+import os
+from unittest.mock import patch, MagicMock
+import importlib
+import sys
+
+# Add the src directory to sys.path
+sys.path.append("packages/deepfix-portal/src")
+
+# Pre-mocking all dependencies that main.py imports
+mock_fastapi = MagicMock()
+mock_cors = MagicMock()
+mock_core = MagicMock()
+mock_server = MagicMock()
+mock_db = MagicMock()
+mock_routes = MagicMock()
+
+sys.modules['fastapi'] = mock_fastapi
+sys.modules['fastapi.middleware.cors'] = mock_cors
+sys.modules['deepfix_core'] = mock_core
+sys.modules['deepfix_core.models'] = mock_core
+sys.modules['deepfix_server'] = mock_server
+sys.modules['deepfix_server.logging'] = mock_server
+sys.modules['deepfix_portal.api.database'] = mock_db
+sys.modules['deepfix_portal.api.routes'] = mock_routes
+
+def test_cors_origins_logic():
+    # Helper to reload main and get its origins
+    def get_main_origins(env_vars):
+        with patch.dict(os.environ, env_vars, clear=True):
+            import deepfix_portal.api.main
+            importlib.reload(deepfix_portal.api.main)
+            from deepfix_portal.api.main import allowed_origins
+            return allowed_origins
+
+    # Test Case 1: No env vars
+    origins = get_main_origins({})
+    assert origins == ["http://localhost:5173", "http://localhost:8844"]
+    print("Test Case 1 passed: No env vars")
+
+    # Test Case 2: FRONTEND_URL only
+    origins = get_main_origins({"FRONTEND_URL": "https://myfrontend.com"})
+    assert origins == ["https://myfrontend.com"]
+    print("Test Case 2 passed: FRONTEND_URL only")
+
+    # Test Case 3: CORS_ALLOWED_ORIGINS only
+    origins = get_main_origins({"CORS_ALLOWED_ORIGINS": "https://origin1.com, https://origin2.com"})
+    assert origins == ["https://origin1.com", "https://origin2.com"]
+    print("Test Case 3 passed: CORS_ALLOWED_ORIGINS only")
+
+    # Test Case 4: Both
+    origins = get_main_origins({
+        "FRONTEND_URL": "https://myfrontend.com",
+        "CORS_ALLOWED_ORIGINS": "https://origin1.com"
+    })
+    assert set(origins) == {"https://myfrontend.com", "https://origin1.com"}
+    print("Test Case 4 passed: Both")
+
+if __name__ == "__main__":
+    try:
+        test_cors_origins_logic()
+        print("\nCORS logic tests passed!")
+    except Exception as e:
+        print(f"CORS logic tests failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
This PR addresses an unrestricted CORS policy in the `deepfix-portal` backend. Previously, `allow_origins=["*"]` was used while `allow_credentials=True` was enabled, which is a security risk and can cause runtime errors in some ASGI servers.

### ⚠️ Risk: The potential impact if left unfixed
An unrestricted CORS policy allows any website to make requests to the API. When combined with `allow_credentials=True`, this could allow a malicious site to perform actions on behalf of a logged-in user (CSRF-like attacks) if the browser doesn't block the wildcard origin for credentialed requests.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix implements a more secure approach by:
1.  Reading `CORS_ALLOWED_ORIGINS` from environment variables (comma-separated).
2.  Including `FRONTEND_URL` if it's set.
3.  Falling back to safe defaults (`http://localhost:5173`, `http://localhost:8844`) only if no environment variables are provided.
4.  Ensuring that `*` is never used as an origin.

A new test file `packages/deepfix-portal/tests/api/test_cors.py` was added to verify the origin construction logic under different environment configurations.


---
*PR created automatically by Jules for task [5715021341075289305](https://jules.google.com/task/5715021341075289305) started by @FadelMamar*